### PR TITLE
feat(admin): Improve Match admin form with dynamic team selection

### DIFF
--- a/tennis_doubles/urls.py
+++ b/tennis_doubles/urls.py
@@ -15,10 +15,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from tournament.views import tournament_grid
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('', tournament_grid, name='tournament_grid')
+    path('api/tournament/', include('tournament.urls')),
+    path('', tournament_grid, name='tournament_grid'),
 ]

--- a/tournament/static/js/match_admin.js
+++ b/tournament/static/js/match_admin.js
@@ -1,0 +1,105 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const tournamentSelect = document.getElementById('id_tournament');
+    const team1Select = document.getElementById('id_team1');
+    const team2Select = document.getElementById('id_team2');
+
+    function createGroupOption(groupName) {
+        const optgroup = document.createElement('optgroup');
+        optgroup.label = groupName;
+        return optgroup;
+    }
+
+    function clearSelect(select) {
+        const currentValue = select.value;  // Store current value before clearing
+        select.innerHTML = '';
+        const emptyOption = document.createElement('option');
+        emptyOption.value = '';
+        emptyOption.textContent = '---------';
+        select.appendChild(emptyOption);
+        return currentValue;  // Return the value that was selected
+    }
+
+    function syncTeamSelects() {
+        // Get selected group from team1 (if any)
+        const team1Selected = team1Select.options[team1Select.selectedIndex];
+        if (team1Selected && team1Selected.closest('optgroup')) {
+            const selectedGroup = team1Selected.closest('optgroup').label;
+            
+            // Hide all options in team2 except those from the same group
+            Array.from(team2Select.getElementsByTagName('option')).forEach(option => {
+                const optgroup = option.closest('optgroup');
+                if (optgroup) {
+                    option.hidden = optgroup.label !== selectedGroup;
+                }
+            });
+        } else {
+            // Show all options if no team is selected
+            Array.from(team2Select.getElementsByTagName('option')).forEach(option => {
+                option.hidden = false;
+            });
+        }
+    }
+
+    async function updateTeams() {
+        const tournamentId = tournamentSelect.value;
+        
+        // Store current values before clearing
+        const currentTeam1 = team1Select.value;
+        const currentTeam2 = team2Select.value;
+        
+        clearSelect(team1Select);
+        clearSelect(team2Select);
+
+        if (!tournamentId) {
+            return;
+        }
+
+        try {
+            const response = await fetch(`/api/tournament/teams/?tournament=${tournamentId}`);
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            
+            const groups = await response.json();
+            
+            groups.forEach(group => {
+                const team1Group = createGroupOption(group.name);
+                const team2Group = createGroupOption(group.name);
+                
+                group.teams.forEach(team => {
+                    const team1Option = document.createElement('option');
+                    team1Option.value = team.id;
+                    team1Option.textContent = team.name;
+                    if (team.id.toString() === currentTeam1) {
+                        team1Option.selected = true;
+                    }
+                    team1Group.appendChild(team1Option);
+
+                    const team2Option = document.createElement('option');
+                    team2Option.value = team.id;
+                    team2Option.textContent = team.name;
+                    if (team.id.toString() === currentTeam2) {
+                        team2Option.selected = true;
+                    }
+                    team2Group.appendChild(team2Option);
+                });
+
+                team1Select.appendChild(team1Group);
+                team2Select.appendChild(team2Group);
+            });
+
+            syncTeamSelects();
+        } catch (error) {
+            console.error('Error fetching teams:', error);
+        }
+    }
+
+    // Add event listeners
+    tournamentSelect.addEventListener('change', updateTeams);
+    team1Select.addEventListener('change', syncTeamSelects);
+
+    // Initialize teams if tournament is already selected
+    if (tournamentSelect.value) {
+        updateTeams();
+    }
+});

--- a/tournament/urls.py
+++ b/tournament/urls.py
@@ -1,0 +1,7 @@
+# tournament/urls.py
+from django.urls import path
+from tournament import views
+
+urlpatterns = [
+    path('teams/', views.teams_by_tournament, name='teams_by_tournament'),
+]

--- a/tournament/views.py
+++ b/tournament/views.py
@@ -1,3 +1,5 @@
+from django.http import JsonResponse
+from django.contrib.admin.views.decorators import staff_member_required 
 from django.shortcuts import render
 from django.db.models import Q, Prefetch, F, Value, CharField, Case, When, IntegerField
 from django.db.models.functions import Concat
@@ -247,3 +249,32 @@ def test_standings(tournament_id, tournament_group_id):
         print(f"Total Games Played: {stat['total_games_played']}")
         print(f"Total Games Won: {stat['total_games_won']}")
         print("---")
+
+@staff_member_required
+def teams_by_tournament(request):
+    tournament_id = request.GET.get('tournament')
+    teams = Team.objects.filter(
+        tournament_group__tournament_id=tournament_id
+    ).select_related(
+        'player1', 
+        'player2', 
+        'tournament_group',
+        'tournament_group__group'
+    ).order_by('tournament_group__group__name')
+    
+    # Group teams by tournament group
+    groups_dict = {}
+    for team in teams:
+        group_name = team.tournament_group.group.name
+        if group_name not in groups_dict:
+            groups_dict[group_name] = {
+                'id': team.tournament_group.id,
+                'name': group_name,
+                'teams': []
+            }
+        groups_dict[group_name]['teams'].append({
+            'id': team.id,
+            'name': f"{team.player1.first_name}/{team.player2.first_name}"
+        })
+    
+    return JsonResponse(list(groups_dict.values()), safe=False)


### PR DESCRIPTION
- Add filtered team dropdowns based on tournament selection
- Group teams by tournament group in dropdowns
- Ensure teams can only be selected from the same tournament group
- Fix team dropdowns not populating when editing existing matches
- Add client-side validation for team selection
- Improve tournament group selection UX with optgroups

The match admin form now provides a better user experience by dynamically
filtering team selections based on the chosen tournament and tournament group.
When editing existing matches, the form correctly loads and displays the
existing team selections.